### PR TITLE
Fixed to reference shell stdout instead of depreciated output

### DIFF
--- a/lib/pdfinfo.js
+++ b/lib/pdfinfo.js
@@ -27,13 +27,13 @@ function pdfinfo (filename, options) {
     var self = this;
     var child = shell.exec('pdfinfo ' + self.options.additional.join(' '));
     if (child.code === 0) {
-      return utils.parse(child.output);
+      return utils.parse(child.stdout);
     }
     else {
       if (!shell.which('pdfinfo')) {
         throw new Error('Sorry, this script requires pdfinfo.');
       }
-      throw new Error("pdfinfo error: "+ child.output);
+      throw new Error("pdfinfo error: "+ child.stdout);
     }
   }
 


### PR DESCRIPTION
Shelljs, a dependency, has changed the structure of the obj returned from 'exec'. This is a fix. 